### PR TITLE
Known limitation about DLB moved to a note

### DIFF
--- a/modules/ROOT/pages/setup.adoc
+++ b/modules/ROOT/pages/setup.adoc
@@ -149,7 +149,10 @@ For Mule version 4.1.x, the following connectors are supported:
 
 == Dedicated Load Balancers
 
-Visualizer supports dedicated load balancers for CloudHub apps using Mule version 3.9.x (version released April 5, 2019 or later). Visualizer cannot correctly resolve dedicated load balancer connections for CloudHub apps using Mule 4 runtime versions at this time.
+Visualizer supports dedicated load balancers for CloudHub apps using Mule version 3.9.x (version released April 5, 2019 or later). 
+
+[NOTE]
+Visualizer cannot correctly resolve dedicated load balancer connections for CloudHub apps using Mule 4 runtime versions at this time.
 
 == Deploy an App
 


### PR DESCRIPTION
As a result of customer tickets that have been filed, we need to call out this known limitation (Visualizer not supporting DLBs for Mule 4) more clearly.