### PR TITLE
Minor setup page update

### DIFF
--- a/modules/ROOT/pages/setup.adoc
+++ b/modules/ROOT/pages/setup.adoc
@@ -27,6 +27,8 @@ Anypoint Visualizer supports the following deployment types:
 * xref:visualizer::standalone-mule-setup.adoc[Standalone Mule]
 * xref:visualizer::runtime-fabric-setup.adoc[Runtime Fabric]
 
+The set up process and supported Mule runtimes differ depending on deployment type. Further details are included in each section.
+
 == Deploy an App
 
 When you deploy an app you want to view in Anypoint Visualizer, ensure that you select a supported version of Mule as the deployment target. See xref:runtime-manager::index.adoc[Runtime Manager] for more information.


### PR DESCRIPTION
This change was based on feedback that user's were confused by a link within the UI that led to this section. In the UI it talks about not using a supported runtime, but then they are directed to a page on deployment types. My goal is to get them to click their deployment type and then find what they want on the next page. Feel free to reword to help make that more clear!