### PR TITLE
W-23365932-hyperforce-australia-cloud-visualizer-kt

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -47,12 +47,12 @@ All API Visualizer features are available on https://anypoint.mulesoft.com/[US C
 
 This table shows feature availability for Hyperforce clouds.
 
-[%header,cols="3a,1a,1a,1a,1a,1a"]
+[%header,cols="3a,1a,1a,1a,1a,1a,1a"]
 |===
 |API Visualizer Feature
 2+^| Americas
 ^| Europe
-2+^| Asia Pacific
+3+^| Asia Pacific
 
 |{empty}
 |US Cloud
@@ -60,6 +60,7 @@ This table shows feature availability for Hyperforce clouds.
 |EU Cloud
 |Japan Cloud
 |India Cloud
+|Australia Cloud
 
 |Architecture
 | Available
@@ -67,6 +68,7 @@ This table shows feature availability for Hyperforce clouds.
 | Available
 | Available
 | Available
+| Planned
 
 |Policies
 | Available
@@ -74,11 +76,13 @@ This table shows feature availability for Hyperforce clouds.
 | Available
 | Available
 | Available
+| Planned
 
 |Troubleshooting
 | Available
 | Planned
 | Available
+| Planned
 | Planned
 | Planned
 |===


### PR DESCRIPTION
## Summary

Replicates India Cloud pattern from PR #109 for Australia Cloud (`au1.platform.mulesoft.com`).

- **`index.adoc`**: Added Australia Cloud column to the Hyperforce feature availability table. Updated column spec from `6` to `7` columns and expanded the Asia Pacific span from `2+` to `3+`. All three features set to `Planned` for Australia Cloud.