### PR TITLE
W-23748914: Add United Kingdom Cloud to API Visualizer feature availability table

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -47,17 +47,18 @@ All API Visualizer features are available on https://anypoint.mulesoft.com/[US C
 
 This table shows feature availability for Hyperforce clouds.
 
-[%header,cols="3a,1a,1a,1a,1a,1a,1a"]
+[%header,cols="3a,1a,1a,1a,1a,1a,1a,1a"]
 |===
 |API Visualizer Feature
 2+^| Americas
-^| Europe
+2+^| Europe
 3+^| Asia Pacific
 
 |{empty}
 |US Cloud
 |Canada Cloud
 |EU Cloud
+|United Kingdom Cloud
 |Japan Cloud
 |India Cloud
 |Australia Cloud
@@ -66,6 +67,7 @@ This table shows feature availability for Hyperforce clouds.
 | Available
 | Available
 | Available
+| Planned
 | Available
 | Available
 | Planned
@@ -74,6 +76,7 @@ This table shows feature availability for Hyperforce clouds.
 | Available
 | Available
 | Available
+| Planned
 | Available
 | Available
 | Planned
@@ -82,6 +85,7 @@ This table shows feature availability for Hyperforce clouds.
 | Available
 | Planned
 | Available
+| Planned
 | Planned
 | Planned
 | Planned


### PR DESCRIPTION
## Summary

Replicates the Australia Cloud pattern from PR #114 for United Kingdom Cloud (`gb1.platform.mulesoft.com`).

- **`index.adoc`**: Added a United Kingdom Cloud column to the Hyperforce feature availability table. Because United Kingdom Cloud is a European region, the column is placed under **Europe** (after EU Cloud): the `cols` spec was expanded from 7 to 8 and the Europe span from `^|` to `2+^|`. All three features (Architecture, Policies, Troubleshooting) are set to `Planned` for United Kingdom Cloud.

## Notes

- Feature availability values default to `Planned` (matching the Australia Cloud rollout). Confirm actual availability before publishing.

Made with [Cursor](https://cursor.com)